### PR TITLE
Add `renderComponent` for flux

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dashboard": "babel-node ./examples/dashboard.jsx",
     "demo": "babel-node ./examples/demo.jsx",
     "prepublish": "npm run build",
-    "test": "mocha -R spec --compilers js:babel/register ./test/endpoint.js"
+    "test": "$(npm bin)/mocha -R spec --compilers js:babel/register ./test/endpoint.js"
   },
   "repository": {
     "type": "git",

--- a/src/render.js
+++ b/src/render.js
@@ -49,7 +49,7 @@ function render(element, opts={}) {
   });
 
   // Returning the screen so the user can attach listeners etc.
-  screen._component = component;
+  screen._component = component._instance;
   return screen;
 }
 

--- a/src/render.js
+++ b/src/render.js
@@ -49,7 +49,22 @@ function render(element, opts={}) {
   });
 
   // Returning the screen so the user can attach listeners etc.
+  screen._component = component;
   return screen;
 }
 
-export {render};
+/**
+ * Renders the given react element with blessed and returns ReactComponent.
+ *
+ * @param  {ReactElement}  element   - Node to update.
+ * @param  {object}        [opts={}] - Options to give to the blessed screen.
+ * @return {ReactComponent}          - The created component.
+ */
+function renderComponent(element, opts={}) {
+  const screen = render(element, opts);
+  // Add screen referrer from component
+  screen._component.screen = screen;
+  return screen._component;
+}
+
+export {render, renderComponent};

--- a/src/render.js
+++ b/src/render.js
@@ -62,8 +62,6 @@ function render(element, opts={}) {
  */
 function renderComponent(element, opts={}) {
   const screen = render(element, opts);
-  // Add screen referrer from component
-  screen._component.screen = screen;
   return screen._component;
 }
 


### PR DESCRIPTION
Some flux require root component to wrap those application context.
react-blessed returns blessed.screen but has no component reference. I added but it's not so clean. Anyway I propose react-blessed's renderer returns it.

For example, redux needs component like this.

```js
export default class Root extends Component {
  render() {
    return (
      <Provider store={store}>
        {() => <CounterApp />}
      </Provider>
    );
  }
}
```

https://github.com/rackt/redux/blob/master/examples/counter/containers/Root.js#L8