### PR TITLE
Fix #5 by monkeypatching ReactComponentEnvironment

### DIFF
--- a/src/ReactBlessedInjection.js
+++ b/src/ReactBlessedInjection.js
@@ -28,8 +28,12 @@ export default function inject() {
     ReactBlessedReconcileTransaction
   );
 
-  // NOTE: very dirty trick due to react@0.14-beta1's current state
-  ReactComponentEnvironment.processChildrenUpdates = Function.prototype;
+  // NOTE: we're monkeypatching ReactComponentEnvironment because
+  // ReactInjection.Component.injectEnvironment() currently throws,
+  // as it's already injected by ReactDOM for backward compat in 0.14 betas.
+  // Read more: https://github.com/Yomguithereal/react-blessed/issues/5
+  ReactComponentEnvironment.processChildrenUpdates = function () {};
+  ReactComponentEnvironment.replaceNodeWithMarkupByID = function () {};
 
   /**
    * Overriding blessed event emitter.


### PR DESCRIPTION
See #5 for reference.

We don't need these hooks in `react-blessed` so making them no-ops as suggested by @yuchi seems to be correct. This fixes the problem in my project. I changed `Function.prototype` to empty functions to be more explicit about the intended meaning.