### PR TITLE
Fix noscript react components

### DIFF
--- a/src/ReactBlessedInjection.js
+++ b/src/ReactBlessedInjection.js
@@ -19,6 +19,8 @@ export default function inject() {
     ReactBlessedReconcileTransaction
   );
 
+  ReactInjection.EmptyComponent.injectEmptyComponent('element');
+
   // NOTE: we're monkeypatching ReactComponentEnvironment because
   // ReactInjection.Component.injectEnvironment() currently throws,
   // as it's already injected by ReactDOM for backward compat in 0.14 betas.


### PR DESCRIPTION
In order to use redux <Provider> and react-router <Router> and <Route> components as well as any other component that returns false or null in render method, react-blessed must render the component type noscript as a blessed component that has no visual influence.