### PR TITLE
Fixed a nasty bug with initial render not being batched

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -43,14 +43,21 @@ function render(element, screen) {
   const id = ReactInstanceHandles.createReactRootID();
 
   // Mounting the app
-  const transaction = ReactUpdates.ReactReconcileTransaction.getPooled(),
-        component = instantiateReactComponent(element);
+  const component = instantiateReactComponent(element);
 
   // Injecting the screen
   ReactBlessedIDOperations.setScreen(screen);
 
-  transaction.perform(() => {
-    component.mountComponent(id, transaction, {});
+  // The initial render is synchronous but any updates that happen during
+  // rendering, in componentWillMount or componentDidMount, will be batched
+  // according to the current batching strategy.
+  ReactUpdates.batchedUpdates(() => {
+    // Batched mount component
+    const transaction = ReactUpdates.ReactReconcileTransaction.getPooled();
+    transaction.perform(() => {
+      component.mountComponent(id, transaction, {});
+    });
+    ReactUpdates.ReactReconcileTransaction.release(transaction);
   });
 
   // Returning the screen so the user can attach listeners etc.


### PR DESCRIPTION
As it turned out, several things in react rely on initial render being batched as any batched update. For example, if you do `setState` from `componentWillMount` in the current setup, the program will crash because of react failing to batch updates. And the react-dom renderer actually performs the batched update it in its render method by

```js
ReactUpdates.batchedUpdates(batchedMountComponentIntoNode, componentInstance, reactRootID, container, shouldReuseMarkup, context);
```

I'm not really advanced in react internals, so please validate my code before merging, I may have done something strange. =)

Here is the example of code failing without this fix:
```jsx
import React, {Component} from 'react';
import blessed from 'blessed';
import {render} from 'react-blessed';

// Rendering a simple centered box
class App extends Component {
  componentWillMount() {
    this.setState({anything: 'will trigger crash here'});
  }
  render() {
    return (
      <box top="center"
           left="center"
           width="50%"
           height="50%"
           border={{type: 'line'}}
           style={{border: {fg: 'blue'}}}>
        Hello World!
      </box>
    );
  }
}

// Creating our screen
const screen = blessed.screen({
  autoPadding: true,
  smartCSR: true,
  title: 'react-blessed hello world'
});

// Adding a way to quit the program
screen.key(['escape', 'q', 'C-c'], function(ch, key) {
  return process.exit(0);
});

// Rendering the React app using our screen
const component = render(<App />, screen);
```