### PR TITLE
pass relevant element into focus/blur handlers

### DIFF
--- a/src/ReactBlessedComponent.js
+++ b/src/ReactBlessedComponent.js
@@ -42,8 +42,12 @@ export default class ReactBlessedComponent {
     this._eventListener = (type, ...args) => {
       const handler = this._currentElement.props['on' + startCase(type).replace(/ /g, '')];
 
-      if (typeof handler === 'function')
-        handler.apply(null, args);
+      if (typeof handler === 'function') {
+        if (type === 'focus' || type === 'blur') {
+          args[0] = ReactBlessedIDOperations.get(this._rootNodeID)
+        }
+        handler(...args);
+      }
     };
   }
 


### PR DESCRIPTION
This patch enables the below code to function according to expectaitons - e.g. that a handler attached to a component receives the node that belongs to that component, not the previous node (in the case of focus) or the next node (in the case of blur). 

```
import React from 'react'

function focus(el) {
  el.style.border.bg = 'red'  //should change border of newly focused element
}

function blur(el) {
  el.style.border.bg = 'white' // should change border of recently blurred element
}

const MyCmp = () => (
  <list 
    onFocus={focus}
    onBlur={blur}
  />
)

export default MyCmp

```