### PR TITLE
fix events

### DIFF
--- a/src/ReactBlessedComponent.js
+++ b/src/ReactBlessedComponent.js
@@ -40,7 +40,7 @@ export default class ReactBlessedComponent {
     // Setting some properties
     this._currentElement = element;
     this._eventListener = (type, ...args) => {
-      const handler = this._currentElement.props['on' + startCase(type)];
+      const handler = this._currentElement.props['on' + startCase(type).replace(/ /g, '')];
 
       if (typeof handler === 'function')
         handler.apply(null, args);


### PR DESCRIPTION
some events come up from blessed with a space in them - e.g. "key down" or "select item" -

joining them together makes the likes of `<list onSelectItem={item=>console.log(item.content)}/>` work 