### PR TITLE
infinite recursion fix

### DIFF
--- a/src/ReactBlessedComponent.js
+++ b/src/ReactBlessedComponent.js
@@ -26,6 +26,7 @@ const CONTENT_TYPES = {string: true, number: true};
 export default class ReactBlessedComponent {
   constructor(tag) {
     this._tag = tag.toLowerCase();
+    this._updating = false;
     this._renderedChildren = null;
     this._previousStyle = null;
     this._previousStyleCopy = null;
@@ -40,6 +41,8 @@ export default class ReactBlessedComponent {
     // Setting some properties
     this._currentElement = element;
     this._eventListener = (type, ...args) => {
+      if (this._updating) return;
+      
       const handler = this._currentElement.props['on' + startCase(type).replace(/ /g, '')];
 
       if (typeof handler === 'function')
@@ -131,7 +134,9 @@ export default class ReactBlessedComponent {
     const {props: {children, ...options}} = nextElement,
           node = ReactBlessedIDOperations.get(this._rootNodeID);
 
+    this._updating = true;
     update(node, solveClass(options));
+    this._updating = false;
 
     // Updating children
     const childrenToUse = children === null ? [] : [].concat(children);


### PR DESCRIPTION
Infinite recursion has been identified with the select event, but it may occur else where. 

Here's the scenario:

* I have a list element with an onSelectItem handler that triggers a redux action
* this in turn triggers a react update lifecycle
* during the cycle, the list element re-renders
* part of blesseds rendering process is to call `select` on *each of the items in the list as they are added*
* this triggers N select events (where N is the amount of items in list)
* each of this triggered events onSelectItem to be triggered, firing a redux action with a  new payload
* so for every item in the list, an update cycle is started
* blessed calls select on all of the items in all of the new update cycles and so on (N to the power of N)
* consequently the process crashes

If we block events during an update cycle, this solves the problem - since the update cycle is synchronous this shouldn't block any actual user events (... right?)