### PR TITLE
bugfix for bug caused by #35

### DIFF
--- a/src/update.js
+++ b/src/update.js
@@ -100,8 +100,7 @@ export default function update(node, options) {
     else if ((key === 'rows' || key === 'data') && node.setData)
       node.setData(value);
 
-    else if (key === 'focused')
-      if (value && !node[key]) node.focus()
+    else if (key === 'focused' && value && !node[key]) node.focus()
 
     // Raw attributes
     else


### PR DESCRIPTION
I made a boo boo - the additional `if` statement under the `else if (key ==='focused')` meant that the `else` statement with the final for loop below was relevant the the additional `if`, not to the `else if` - which means no keys are being updated (e.g. height width etc). Here's a fix... sorry!