### PR TITLE
update _currentElement to nextElement to trigger correct event handlers

### DIFF
--- a/src/ReactBlessedComponent.js
+++ b/src/ReactBlessedComponent.js
@@ -132,6 +132,10 @@ export default class ReactBlessedComponent {
           node = ReactBlessedIDOperations.get(this._rootNodeID);
 
     update(node, solveClass(options));
+    
+    if (this._currentElement !== nextElement) {
+      this._currentElement = nextElement
+    }
 
     // Updating children
     const childrenToUse = children === null ? [] : [].concat(children);


### PR DESCRIPTION
it seems in some cases old event handlers from a prior render are triggered instead of the latest event handlers - this includes an event handler that accesses a scope reference, the value of the reference from a prior render applies instead of the most up to date reference (e.g. a boolean may have changed from true to false, but the old event handler still references the old `true` value). 

This is due to  `this._currentElement` being accessed in the event listener, but not being updated in cases where a re-render leads to the creation of a new element. 