### PR TITLE
Always include node in event callbacks

### DIFF
--- a/examples/form.jsx
+++ b/examples/form.jsx
@@ -11,7 +11,7 @@ class Form extends Component {
       name: '',
     };
 
-    this.submit = data => this.setState(state => ({name: data}));
+    this.submit = (_form, data) => this.setState(state => ({name: data}));
     this.cancel = _ => console.log('Form canceled');
   }
   render() {

--- a/examples/framer.js
+++ b/examples/framer.js
@@ -47,7 +47,7 @@ class Demo extends React.Component {
     */
   }
 
-  handleMouseDown = (pos, pressY, event) => {
+  handleMouseDown = (pos, pressY, node, event) => {
     if (this.state.isPressed === false) {
       const {y} = event;
       this.setState({
@@ -57,14 +57,14 @@ class Demo extends React.Component {
         originalPosOfLastPressed: pos,
       });
     } else {
-      this.handleMouseMove({
+      this.handleMouseMove(node, {
         ...event,
         action: 'fake-mousemove',
       });
     }
   };
 
-  handleMouseMove = (event) => {
+  handleMouseMove = (_node, event) => {
     if (event.action !== 'fake-mousemove') {
       return;
     }

--- a/src/fiber/events.js
+++ b/src/fiber/events.js
@@ -25,9 +25,8 @@ const eventListener = (node, event, ...args) => {
   */
 
   if (typeof handler === 'function') {
-    if (event === 'focus' || event === 'blur') {
-      args[0] = node;
-    }
+    args[0] = node;
+
     handler(...args);
   }
 };


### PR DESCRIPTION
This is a big change, but I think it would make development a lot more
pleasant.

Similar to working with React in a browser context, there are a lot of
reasons that having a reference to a `Node` is useful.

One of the most basic React DOM cases is text inputs. You create the
input, and use `event.target.value` to set the state of your
component.

In react-blessed, having access to nodes in events would be useful,
but they're largely not available (except `focus` and `blur` events).

Because of this, I end up needing to create refs for almost every
element, which isn't _necessarily_ bad, but my preference would be to
just have access to the node in event callbacks.

Please let me know what you think of this change!