### PR TITLE
Add focused prop to form in form example so the example works on Windows

### DIFF
--- a/examples/form.jsx
+++ b/examples/form.jsx
@@ -19,6 +19,7 @@ class Form extends Component {
       <form
         keys
         vi
+        focused
         onSubmit={this.submit}
         onReset={this.cancel}
         left="5%"


### PR DESCRIPTION
Mouse events don't work on windows for Blessed, so this change ensures that the form field is focused when the example starts.