### PR TITLE
Events shall be removed for all descendants

### DIFF
--- a/src/fiber/fiber.js
+++ b/src/fiber/fiber.js
@@ -191,6 +191,9 @@ const createBlessedRenderer = function(blessed) {
     ) : void {
       parentInstance.remove(child);
       child.off('event', child._eventListener);
+      child.forDescendants(function(el) {
+        el.off('event', child._eventListener);
+      });
       child.destroy();
     },
 
@@ -200,6 +203,9 @@ const createBlessedRenderer = function(blessed) {
     ) : void {
       parentInstance.remove(child);
       child.off('event', child._eventListener);
+      child.forDescendants(function(el) {
+        el.off('event', child._eventListener);
+      });
       child.destroy();
     },
 


### PR DESCRIPTION
I have experienced a weird problem that even if a component is no longer on the screen, its event handler (a keyboard callback in my case) is still responding to the keyboard events. 

The reason for this bug is:
1. In blessed, `Node.destroy` won't unbind events for the descendants of the node. 
2. React fiber only calls `removeChildFromContainer` or `removeChild` for the top level element being removed (I reached this conclusion by using a . Thus if we have a component `<Box><TextBox/></Box>`  to be removed, the inner `TextBox` won't have a chance to cleanup its event handlers.

https://github.com/chjj/blessed/blob/eab243fc7ad27f1d2932db6134f7382825ee3488/lib/widgets/node.js#L176-L183

So the fix is to explicitly unbind events for all the descendants of the current element being removed.