### PR TITLE
Bind this context in event handlers

### DIFF
--- a/src/fiber/events.js
+++ b/src/fiber/events.js
@@ -31,7 +31,7 @@ const eventListener = (node, event, ...args) => {
     if (event === 'focus' || event === 'blur') {
       args[0] = node;
     }
-    handler(...args);
+    handler.apply(node, ...args);
   }
 };
 


### PR DESCRIPTION
So we can get the underlying blessed element in callbacks. This could be handy, e.g. to get the width/height of the element. Otherwise the only way I can think of to achieve that is to use the [ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) trick of react to get the element, which is tedious and error-prone. 